### PR TITLE
Add Timeline View icon to right sidebar ribbon

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -52,6 +52,7 @@ export default class TimingPlugin extends Plugin {
 	weeklySectionManager: WeeklySectionManager;
 	dataTransformer: DataTransformer;
 	ribbonIconEl: HTMLElement;
+	timelineRibbonIconEl: HTMLElement;
 	statusBarItemEl: HTMLElement;
 	private updateInterval: NodeJS.Timeout | null = null;
 	private timelineView: TimingTimelineView | null = null;
@@ -161,6 +162,15 @@ export default class TimingPlugin extends Plugin {
 		);
 
 		this.updateRibbonIcon(RibbonIconState.DISABLED);
+
+		// Add timeline ribbon icon
+		this.timelineRibbonIconEl = this.addRibbonIcon(
+			"activity",
+			"Open Timing Timeline",
+			async (evt: MouseEvent) => {
+				await this.openTimelineView();
+			},
+		);
 	}
 
 	private setupStatusBar(): void {


### PR DESCRIPTION
## Summary
- Add dedicated Timeline View icon to the right sidebar ribbon for quick access
- Users can now open the timeline visualization with a single click from the sidebar
- Improves UX by providing intuitive access to timing data visualization

## Changes
- **New ribbon icon**: Added `timelineRibbonIconEl` property to manage timeline-specific ribbon icon
- **Activity icon**: Uses "activity" icon symbol to represent timeline/activity visualization
- **Click handler**: Directly opens Timeline View when clicked
- **Tooltip**: Added "Open Timing Timeline" tooltip for clear user guidance
- **Integration**: Seamlessly integrates with existing ribbon icon setup

## User Experience Improvements
- **Quick access**: No need to navigate through command palette or menus
- **Visual consistency**: Follows Obsidian's ribbon icon patterns and styling
- **Intuitive design**: Activity icon clearly represents timeline functionality
- **Accessibility**: Proper tooltip provides clear action description

## Technical Implementation
- Utilizes Obsidian's `addRibbonIcon` API for native sidebar integration
- Maintains separation from existing settings ribbon icon
- Follows established plugin architecture patterns
- No breaking changes to existing functionality

## Test Plan
- [x] Icon appears in right sidebar ribbon
- [x] Clicking icon successfully opens Timeline View
- [x] Tooltip displays correct text on hover
- [x] Icon styling matches Obsidian theme (light/dark mode)
- [x] No conflicts with existing ribbon functionality
- [x] Build completes without errors

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)